### PR TITLE
Update approximate infeasibility criteria.

### DIFF
--- a/src/termination.jl
+++ b/src/termination.jl
@@ -60,8 +60,8 @@ mutable struct TerminationCriteria
   If the following two conditions hold we say that we have obtained an
   approximate dual ray, which is an approximate certificate of primal
   infeasibility.
-    (1) dual_ray_objective > eps_primal_infeasible,
-    (2) max_dual_ray_infeasibility / dual_ray_objective <
+    (1) dual_ray_objective > 0.0,
+    (2) max_dual_ray_infeasibility / dual_ray_objective <=
         eps_primal_infeasible.
   """
   eps_primal_infeasible::Float64
@@ -70,11 +70,11 @@ mutable struct TerminationCriteria
   If the following three conditions hold we say we have obtained an
   approximate primal ray, which is an approximate certificate of dual
   infeasibility.
-  (1) primal_ray_linear_objective < -eps_dual_infeasible,
-  (2) max_primal_ray_infeasibility / (-primal_ray_linear_objective) <
-      eps_dual_infeasible
-  (3) primal_ray_quadratic_norm / (-primal_ray_linear_objective) <
-      eps_dual_infeasible.
+    (1) primal_ray_linear_objective < 0.0,
+    (2) max_primal_ray_infeasibility / (-primal_ray_linear_objective) <=
+        eps_dual_infeasible,
+    (3) primal_ray_quadratic_norm / (-primal_ray_linear_objective) <=
+        eps_dual_infeasible.
   """
   eps_dual_infeasible::Float64
 
@@ -202,10 +202,10 @@ function primal_infeasibility_criteria_met(
   infeasibility_information::InfeasibilityInformation,
 )
   ii = infeasibility_information
-  if ii.dual_ray_objective <= eps_primal_infeasible
+  if ii.dual_ray_objective <= 0.0
     return false
   end
-  return ii.max_dual_ray_infeasibility / ii.dual_ray_objective <
+  return ii.max_dual_ray_infeasibility / ii.dual_ray_objective <=
          eps_primal_infeasible
 end
 
@@ -217,12 +217,12 @@ function dual_infeasibility_criteria_met(
   infeasibility_information::InfeasibilityInformation,
 )
   ii = infeasibility_information
-  if ii.primal_ray_linear_objective >= -eps_dual_infeasible
+  if ii.primal_ray_linear_objective >= 0.0
     return false
   end
-  return ii.max_primal_ray_infeasibility / (-ii.primal_ray_linear_objective) <
+  return ii.max_primal_ray_infeasibility / (-ii.primal_ray_linear_objective) <=
          eps_dual_infeasible &&
-         ii.primal_ray_quadratic_norm / (-ii.primal_ray_linear_objective) <
+         ii.primal_ray_quadratic_norm / (-ii.primal_ray_linear_objective) <=
          eps_dual_infeasible
 end
 

--- a/test/test_mirror_prox.jl
+++ b/test/test_mirror_prox.jl
@@ -359,7 +359,7 @@ end
     problem.right_hand_side[3] = 8
     output = FirstOrderLp.optimize(parameters, problem)
     final_stats = output.iteration_stats[end]
-    @test final_stats.convergence_information[1].dual_objective >= 1e6
+    @test output.termination_reason == FirstOrderLp.PRIMAL_INFEASIBLE
   end
   @testset "Primal infeasible instance 2" begin
     parameters = generate_mirror_prox_params(

--- a/test/test_primal_dual_hybrid_gradient.jl
+++ b/test/test_primal_dual_hybrid_gradient.jl
@@ -362,7 +362,7 @@ end
     problem.right_hand_side[3] = 8
     output = FirstOrderLp.optimize(parameters, problem)
     final_stats = output.iteration_stats[end]
-    @test final_stats.convergence_information[1].dual_objective >= 1e6
+    @test output.termination_reason == FirstOrderLp.PRIMAL_INFEASIBLE
   end
   @testset "LP without bounds" begin
     parameters = generate_primal_dual_hybrid_gradient_params(


### PR DESCRIPTION
This changes the approximate infeasibility criteria for FirstOrderLp to be:
  primal infeasibility:
    (1) dual_ray_objective > 0.0 (was >= eps_primal_infeasible),
    (2) max_dual_ray_infeasibility / dual_ray_objective <=
        eps_primal_infeasible (was <).
  dual infeasibility:
    (1) primal_ray_linear_objective < 0.0 (was <= eps_dual_infeasible),
    (2) max_primal_ray_infeasibility / (-primal_ray_linear_objective) <=
        eps_dual_infeasible (was <),
    (3) primal_ray_quadratic_norm / (-primal_ray_linear_objective) <=
        eps_dual_infeasible (was <).

The motivation for changing (1) is primarily that for a non-zero epsilon,
there are simple instances that converge to a ray_objective between 0 and
epsilon, so that no matter how long we run, FirstOrderLp would never be able to
terminate. It also eliminates an annoying non-monoticity for infeasibility with
respect to epsilon.

The motivation for changing (2) is just that it allows 0.0 to be a meaningful
value for epsilon.  Otherwise a precisely feasible ray would be rejected by
epsilon == 0.0.  This was actually hit by one of the test cases ("Infeasible
instance" for PDHG, "Primal infeasible instance" for mirror prox) which used to
fail to detect infeasibility because it was using epsilon = 0.0, and hence
diverged, but now detects infeasibility.