### PR TITLE
CI configuration using GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
         os: [ubuntu-latest]
         arch: [x64]
     steps:
+    # TODO: Add julia-actions/julia-format
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:


### PR DESCRIPTION
Based on the template at https://github.com/invenia/PkgTemplates.jl/blob/master/templates/github/workflows/CI.yml, after stripping it down and adding custom steps to test the standalone scripts.