### PR TITLE
Fix "no_restart" argument to solve_qp

### DIFF
--- a/scripts/solve_qp.jl
+++ b/scripts/solve_qp.jl
@@ -406,7 +406,7 @@ end
 
 function string_to_restart_scheme(restart_scheme::String)
   if restart_scheme == "no_restart"
-    return FirstOrderLp.NO_RESTART
+    return FirstOrderLp.NO_RESTARTS
   elseif restart_scheme == "adaptive_normalized"
     return FirstOrderLp.ADAPTIVE_NORMALIZED
   elseif restart_scheme == "adaptive_distance"


### PR DESCRIPTION
`NO_RESTARTS` is a `RestartScheme`, while `NO_RESTART` is a `RestartChoice` (the latter will soon be renamed to `RESTART_CHOICE_NO_RESTART`.