### PR TITLE
Cache the dual product

### DIFF
--- a/src/primal_dual_hybrid_gradient.jl
+++ b/src/primal_dual_hybrid_gradient.jl
@@ -645,9 +645,11 @@ function optimize(
     # for the above minimization and the cases where g(x) is infinite - there
     # isn't officially any projection step in the algorithm.
 
-    primal_gradient =
-      problem.objective_matrix * current_primal_solution .+
-      problem.objective_vector .- current_dual_product
+    primal_gradient = compute_primal_gradient_from_dual_product(
+      problem,
+      current_primal_solution,
+      current_dual_product,
+    )
 
     next_primal =
       current_primal_solution .- primal_gradient ./ primal_norm_params

--- a/src/saddle_point.jl
+++ b/src/saddle_point.jl
@@ -1039,8 +1039,20 @@ function compute_primal_gradient(
   primal_solution::AbstractVector{Float64},
   dual_solution::AbstractVector{Float64},
 )
+  return compute_primal_gradient_from_dual_product(
+    problem,
+    primal_solution,
+    problem.constraint_matrix' * dual_solution,
+  )
+end
+
+function compute_primal_gradient_from_dual_product(
+  problem::QuadraticProgrammingProblem,
+  primal_solution::AbstractVector{Float64},
+  dual_product::AbstractVector{Float64},
+)
   return problem.objective_matrix * primal_solution .+
-         problem.objective_vector .- problem.constraint_matrix' * dual_solution
+         problem.objective_vector .- dual_product
 end
 
 function compute_dual_gradient(


### PR DESCRIPTION
Gives a speed-up on neos-1122047 from 36s to 28s (PDHG default settings, 1e-6 convergence) and on neos-2075418-temuka from 59s to 50s (1k iteration limit). I did observe that the solution trajectory changes slightly. I attribute this to numerical noise.
Note that we'd expect a 33% speedup if KKT passes were the overwhelmingly dominant part of the computation. This doesn't appear to be true, at least on these instances.