### PR TITLE
Minor fix and CI setup for Julia 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1.5']
+        version: ['1.5', '1.6']
         os: [ubuntu-latest]
         arch: [x64]
     steps:

--- a/test/test_mirror_prox.jl
+++ b/test/test_mirror_prox.jl
@@ -297,7 +297,7 @@ end
     )
     problem = example_lp()
     output = FirstOrderLp.optimize(parameters, problem)
-    @test output.primal_solution ≈ [1.0; 0.0; 6.0; 2.0] atol = 1.0e-9
+    @test output.primal_solution ≈ [1.0; 0.0; 6.0; 2.0] atol = 1.0e-8
     @test output.dual_solution ≈ [0.5; 4.0; 0.0] atol = 1.0e-9
   end
   @testset "Quadratic Programming 1 restart_scheme=ADAPTIVE_NORMALIZED" begin


### PR DESCRIPTION
For now, we can keep compatibility with both versions. After checking for performance regressions, I think we can transition to Julia 1.6 exclusively.