### PR TITLE
Tweak message in format_check.yml

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -30,7 +30,7 @@ jobs:
           if out == ""
               exit(0)
           else
-              @error "The following files are not properly formatted:"
+              @info "The following files are not properly formatted:"
               write(stdout, out)
               @info "See the README for how to run the auto-formatter."
               exit(1)


### PR DESCRIPTION
Re https://github.com/google-research/FirstOrderLp.jl/pull/28#discussion_r611837688:

This makes the error message a bit easier to read. We don't need an `@error`, because the exit code causes the pass to fail.