### PR TITLE
Drop support for Julia 1.5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1.5', '1.6']
+        version: ['1.6']
         os: [ubuntu-latest]
         arch: [x64]
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ publications and is not a "solver" per se.
 
 ## One-time setup
 
-Install Julia 1.5.2 or later. From the root directory of the repository, run:
+Install Julia 1.6.0 or later. From the root directory of the repository, run:
 
 ```shell
 $ julia --project=scripts -e 'import Pkg; Pkg.instantiate()'


### PR DESCRIPTION
As noted in https://github.com/google-research/FirstOrderLp.jl/pull/32#discussion_r615943004, Manifest files generated in Julia 1.6 aren't backwards compatible with Julia 1.5. I don't think it's worth the effort to make sure we use only Julia 1.5 when manipulating packages.