### PR TITLE
JSON to CSV script

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,5 +53,3 @@ jobs:
             cat /tmp/dataset.csv
             exit 1
           fi
-
-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,8 +37,22 @@ jobs:
       - name: "scripts project setup"
         run: julia --project=$GITHUB_WORKSPACE/scripts -e 'import Pkg; Pkg.instantiate()'
       - name: "solve_qp.jl test"
-        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_qp.jl --instance_path test/trivial_lp_model.mps --method pdhg --output_dir /tmp
+        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_qp.jl --instance_path test/trivial_lp_model.mps --method pdhg --output_dir /tmp/pdhg
       - name: "solve_lp_external.jl test (SCS)"
-        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_lp_external.jl --instance_path test/trivial_lp_model.mps --solver scs-indirect --tolerance 1e-7 --output_dir /tmp
+        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_lp_external.jl --instance_path test/trivial_lp_model.mps --solver scs-indirect --tolerance 1e-7 --output_dir /tmp/scs
       - name: "solve_lp_external.jl test (HiGHS)"
-        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_lp_external.jl --instance_path test/trivial_lp_model.mps --solver highs-ipm --tolerance 1e-7 --output_dir /tmp
+        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_lp_external.jl --instance_path test/trivial_lp_model.mps --solver highs-ipm --tolerance 1e-7 --output_dir /tmp/highs
+      - name: "process_json_to_csv"
+        run: |
+          echo '{"datasets": [' >/tmp/layout.json
+          echo '{"name": "pdhg", "logs_directory": "/tmp/pdhg"},' >> /tmp/layout.json
+          echo '{"name": "scs", "logs_directory": "/tmp/scs"}]}' >>/tmp/layout.json
+          julia --project=benchmarking benchmarking/process_json_to_csv.jl \
+            /tmp/layout.json /tmp/dataset.csv
+          if [[ $(wc -l </tmp/dataset.csv) != 3 ]]; then
+            echo "Unexpected number of lines in dataset.csv"
+            cat /tmp/dataset.csv
+            exit 1
+          fi
+
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,13 +42,12 @@ jobs:
         run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_lp_external.jl --instance_path test/trivial_lp_model.mps --solver scs-indirect --tolerance 1e-7 --output_dir /tmp/scs
       - name: "solve_lp_external.jl test (HiGHS)"
         run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_lp_external.jl --instance_path test/trivial_lp_model.mps --solver highs-ipm --tolerance 1e-7 --output_dir /tmp/highs
+      - name: "benchmarking project setup"
+        run: julia --project=$GITHUB_WORKSPACE/benchmarking -e 'import Pkg; Pkg.instantiate()'
       - name: "process_json_to_csv"
         run: |
-          echo '{"datasets": [' >/tmp/layout.json
-          echo '{"name": "pdhg", "logs_directory": "/tmp/pdhg"},' >> /tmp/layout.json
-          echo '{"name": "scs", "logs_directory": "/tmp/scs"}]}' >>/tmp/layout.json
-          julia --project=benchmarking benchmarking/process_json_to_csv.jl \
-            /tmp/layout.json /tmp/dataset.csv
+          echo '{"datasets": [ {"name": "pdhg", "logs_directory": "/tmp/pdhg"}, {"name": "scs", "logs_directory": "/tmp/scs"}]}' >/tmp/layout.json
+          julia --project=$GITHUB_WORKSPACE/benchmarking $GITHUB_WORKSPACE/benchmarking/process_json_to_csv.jl /tmp/layout.json /tmp/dataset.csv
           if [[ $(wc -l </tmp/dataset.csv) != 3 ]]; then
             echo "Unexpected number of lines in dataset.csv"
             cat /tmp/dataset.csv

--- a/benchmarking/Manifest.toml
+++ b/benchmarking/Manifest.toml
@@ -6,6 +6,15 @@ git-tree-sha1 = "370cafc70604b2522f2c7cf9915ebcd17b4cd38b"
 uuid = "ae81ac8f-d209-56e5-92de-9978fef736f9"
 version = "0.1.2+0"
 
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f1b523983a58802c4695851926203b36e28f09db"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.3.0"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
 [[ArnoldiMethod]]
 deps = ["LinearAlgebra", "Random", "StaticArrays"]
 git-tree-sha1 = "f87e559f87a45bece9c9ed97458d3afe98b1ebb9"
@@ -13,10 +22,7 @@ uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
 version = "0.1.0"
 
 [[Artifacts]]
-deps = ["Pkg"]
-git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.3.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -33,6 +39,12 @@ git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
 version = "1.0.6+5"
 
+[[CSV]]
+deps = ["Dates", "Mmap", "Parsers", "PooledArrays", "SentinelArrays", "Tables", "Unicode"]
+git-tree-sha1 = "6d4242ef4cb1539e7ede8e01a47a32365e0a34cd"
+uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+version = "0.8.4"
+
 [[Calculus]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
@@ -41,9 +53,9 @@ version = "0.5.1"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "a66109c73612c63b10923ac446fddb0f0d21a593"
+git-tree-sha1 = "bd0cc939d94b8bd736dce5bbbe0d635db9f94af7"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.40"
+version = "0.9.41"
 
 [[CodecBzip2]]
 deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
@@ -70,16 +82,35 @@ uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "3.27.0"
 
 [[CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
+deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.3.4+0"
+
+[[Crayons]]
+git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.4"
+
+[[DataAPI]]
+git-tree-sha1 = "dfb3b7e89e395be1e25c2ad6d7690dc29cc53b1d"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.6.0"
+
+[[DataFrames]]
+deps = ["Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrettyTables", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "6e5452d9cf401ed9048e1cde93815be53d951079"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "1.0.2"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
 git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 version = "0.18.9"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -105,23 +136,52 @@ version = "1.0.2"
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[FirstOrderLp]]
+deps = ["GZip", "LinearAlgebra", "Logging", "Printf", "QPSReader", "Random", "SparseArrays", "Statistics", "StatsBase", "StructTypes"]
+path = ".."
+uuid = "29002642-da4a-11e8-3a94-39bc61281718"
+version = "0.0.0"
+
+[[Formatting]]
+deps = ["Printf"]
+git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.4.2"
+
 [[ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
 git-tree-sha1 = "e2af66012e08966366a43251e1fd421522908be6"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
 version = "0.10.18"
 
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
 [[GMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "15abc5f976569a1c9d651aff02f7222ef305eb2a"
+deps = ["Artifacts", "Libdl"]
 uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
-version = "6.1.2+6"
+
+[[GZip]]
+deps = ["Libdl"]
+git-tree-sha1 = "039be665faf0b8ae36e089cd694233f5dee3f7d6"
+uuid = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
+version = "0.5.1"
+
+[[Glob]]
+git-tree-sha1 = "4df9f7e06108728ebf00a0a11edee4b29a482bb2"
+uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
+version = "1.3.0"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "0e67ed09b3d89a28bb804ef5b886499f3a40a0cb"
+git-tree-sha1 = "b855bf8247d6e946c75bb30f593bfe7fe591058d"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.7"
+version = "0.9.8"
 
 [[Inflate]]
 git-tree-sha1 = "f5fc07d4e706b84f72d54eedcc1c13d92fb0871c"
@@ -138,11 +198,22 @@ version = "0.5.0"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[InvertedIndices]]
+deps = ["Test"]
+git-tree-sha1 = "15732c475062348b0165684ffe28e85ea8396afc"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.0.0"
+
 [[Ipopt_jll]]
 deps = ["ASL_jll", "Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "MUMPS_seq_jll", "OpenBLAS32_jll", "Pkg"]
 git-tree-sha1 = "82124f27743f2802c23fcb05febc517d0b15d86e"
 uuid = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 version = "3.13.4+2"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
 
 [[JLLWrappers]]
 deps = ["Preferences"]
@@ -156,6 +227,12 @@ git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.1"
 
+[[JSON3]]
+deps = ["Dates", "Mmap", "Parsers", "StructTypes", "UUIDs"]
+git-tree-sha1 = "65798ad6ddb0d7068f2b1885e0b0d876efca16f5"
+uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+version = "1.8.1"
+
 [[JSONSchema]]
 deps = ["HTTP", "JSON", "ZipFile"]
 git-tree-sha1 = "b84ab8139afde82c7c65ba2b792fe12e01dd7307"
@@ -168,9 +245,21 @@ git-tree-sha1 = "e6eaa873100e72fbe185516a889ffeb8d0adeea3"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 version = "0.21.7"
 
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -223,13 +312,20 @@ uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 version = "1.0.3"
 
 [[MbedTLS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
+deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+1"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "4ea90bd5d3985ae1f9a908bd4500ae88921c5ce7"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.0.0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
 [[MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
@@ -243,21 +339,19 @@ uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "0.3.5"
 
 [[NetworkOptions]]
-git-tree-sha1 = "ed3157f48a05543cce9b241e1f2815f7e843d96e"
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
 
 [[OpenBLAS32_jll]]
-deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
-git-tree-sha1 = "793b33911239d2651c356c823492b58d6490d36a"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "ba4a8f683303c9082e84afba96f25af3c7fb2436"
 uuid = "656ef2d0-ae68-5445-9ca0-591084a874a2"
-version = "0.3.9+4"
+version = "0.3.12+1"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9db77584158d0ab52307f8c04f8e7c08ca76b5b3"
+git-tree-sha1 = "b9b8b8ed236998f91143938a760c2112dceeb2b4"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.3+4"
+version = "0.5.4+0"
 
 [[OrderedCollections]]
 git-tree-sha1 = "4fa2ba51070ec13fcc7517db714445b4ab986bdf"
@@ -271,8 +365,14 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PooledArrays]]
+deps = ["DataAPI", "Future"]
+git-tree-sha1 = "cde4ce9d6f33219465b55162811d8de8139c0414"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "1.2.1"
 
 [[Preferences]]
 deps = ["TOML"]
@@ -280,17 +380,34 @@ git-tree-sha1 = "ea79e4c9077208cd3bc5d29631a26bc0cff78902"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 version = "1.2.1"
 
+[[PrettyTables]]
+deps = ["Crayons", "Formatting", "Markdown", "Reexport", "Tables"]
+git-tree-sha1 = "b60494adf99652d220cdef46f8a32232182cc22d"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "1.0.1"
+
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[QPSReader]]
+deps = ["Logging", "Pkg"]
+git-tree-sha1 = "7d5d7a3d45e4c53b80dd7eb1e423d3a822192c77"
+uuid = "10f199a5-22af-520b-b891-7ce84a7b1bd0"
+version = "0.2.0"
+
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+git-tree-sha1 = "57d8440b0c7d98fc4f889e478e80f268d534c9d5"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.0.0"
 
 [[SCIP]]
 deps = ["Ipopt_jll", "Libdl", "MathOptInterface", "SCIP_jll"]
@@ -307,6 +424,12 @@ version = "0.1.2+1"
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
+[[SentinelArrays]]
+deps = ["Dates", "Random"]
+git-tree-sha1 = "6ccde405cf0759eba835eb613130723cb8f10ff9"
+uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+version = "1.2.16"
+
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
@@ -322,6 +445,12 @@ version = "0.9.3"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "2ec1962eba973f383239da22e75218565c390a96"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.0.0"
 
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
@@ -343,14 +472,51 @@ version = "1.1.2"
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[[StatsAPI]]
+git-tree-sha1 = "1958272568dc176a1d881acb797beb909c785510"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.0.0"
+
+[[StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "2f6792d523d7448bbe2fec99eca9218f06cc746d"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.8"
+
+[[StructArrays]]
+deps = ["Adapt", "DataAPI", "Tables"]
+git-tree-sha1 = "44b3afd37b17422a62aea25f04c1f7e09ce6b07f"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.5.1"
+
+[[StructTypes]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "e36adc471280e8b346ea24c5c87ba0571204be7a"
+uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+version = "1.7.2"
+
 [[TOML]]
 deps = ["Dates"]
-git-tree-sha1 = "44aaac2d2aec4a850302f9aa69127c74f0c3787e"
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.3"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "c9d2d262e9a327be1f35844df25fe4561d258dc9"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.4.2"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TranscodingStreams]]
@@ -360,9 +526,9 @@ uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.9.5"
 
 [[URIs]]
-git-tree-sha1 = "7855809b88d7b16e9b029afd17880930626f54a2"
+git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.2.0"
+version = "1.3.0"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -378,13 +544,19 @@ uuid = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 version = "0.9.3"
 
 [[Zlib_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "320228915c8debb12cb434c59057290f0834dbf6"
+deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+18"
 
 [[bliss_jll]]
 deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "efa0ae50a40cdf404e18ce375dfb764001f38b92"
 uuid = "508c9074-7a14-5c94-9582-3d4bc1871065"
 version = "0.73.0+1"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/benchmarking/Project.toml
+++ b/benchmarking/Project.toml
@@ -1,4 +1,11 @@
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+FirstOrderLp = "29002642-da4a-11e8-3a94-39bc61281718"
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 SCIP = "82193955-e24f-5292-bf16-6f2c5261a85f"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,7 +1,7 @@
 # Benchmarking
 
-This directory contains scripts for generating datasets used for benchmarking
-FirstOrderLp.
+This directory contains scripts for generating datasets and processing results
+for benchmarking FirstOrderLp.
 
 ## Filtered and preprocessed MIPLIB 2017 collection dataset
 
@@ -70,3 +70,26 @@ $ julia --project=. generate_pagerank_lp.jl --num_nodes 10000 \
     --approx_num_edges 30000 --random_seed 1 \
     --output_filename ~/pagerank.10k.mps.gz
 ```
+## Procesing JSON results
+
+`solve_qp.jl` and `solve_lp_external.jl` output JSON files with solve
+statistics. Use `process_json_to_csv.jl` to process collections of these files
+into a CSV file for analysis.
+
+For example (from the `FirstOrderLp.jl` root directory),
+
+```sh
+$ julia --project=scripts scripts/solve_qp.jl \
+--instance_path test/trivial_lp_model.mps --method pdhg \
+--output_dir /tmp/first_order_lp_solve
+$ julia --project=scripts scripts/solve_lp_external.jl \
+--instance_path test/trivial_lp_model.mps --solver scs-indirect \
+--tolerance 1e-7 --output_dir /tmp/scs_solve
+$ echo '{"datasets": [
+   {"name": "pdhg", "logs_directory": "/tmp/first_order_lp_solve"},
+   {"name": "scs", "logs_directory": "/tmp/scs_solve"}]}' >/tmp/layout.json
+$ julia --project=benchmarking benchmarking/process_json_to_csv.jl \
+/tmp/layout.json /tmp/dataset.csv
+```
+
+This outputs to `/tmp/dataset.csv`.

--- a/benchmarking/process_json_to_csv.jl
+++ b/benchmarking/process_json_to_csv.jl
@@ -163,7 +163,7 @@ function read_dataset(dataset_list::DatasetList)::DataFrame
 end
 
 if length(ARGS) != 2
-  error("Usage: process_json_to_csv.jl dataset_layout_csv output_csv")
+  error("Usage: process_json_to_csv.jl dataset_list_json output_csv")
 end
 
 dataset_list = JSON3.read(read(ARGS[1], String), DatasetList)

--- a/benchmarking/process_json_to_csv.jl
+++ b/benchmarking/process_json_to_csv.jl
@@ -36,7 +36,7 @@
 # $ julia --project=. process_json_to_csv.jl /tmp/layout.json /tmp/dataset.csv
 #
 # will generate a result file in /tmp/dataset.csv containing the summary of each
-# solve in all of four directories, with columns identifying the corresponding
+# solve in all of four directories, with a column identifying the corresponding
 # configuration.
 
 import CSV
@@ -112,8 +112,8 @@ function solve_log_to_csv_row(
   experiment_name::String,
 )::CsvRow
   row = CsvRow()
-  set_matching_fields(row, log)
   row.experiment_name = experiment_name
+  set_matching_fields(row, log)
   row.cumulative_kkt_matrix_passes =
     log.solution_stats.cumulative_kkt_matrix_passes
 
@@ -147,8 +147,8 @@ StructTypes.StructType(::Type{DatasetList}) = StructTypes.Struct()
 
 function read_dataset(dataset_list::DatasetList)::DataFrame
   rows = CsvRow[]
-  for name_and_location in dataset_list.datasets
-    logs_directory = name_and_location.logs_directory
+  for dataset in dataset_list.datasets
+    logs_directory = dataset.logs_directory
 
     log_files = Glob.glob("*_summary.json", logs_directory)
     if length(log_files) == 0
@@ -156,7 +156,7 @@ function read_dataset(dataset_list::DatasetList)::DataFrame
     end
     for filename in log_files
       log = JSON3.read(read(filename, String), FirstOrderLp.SolveLog)
-      push!(rows, solve_log_to_csv_row(log, name_and_location.name))
+      push!(rows, solve_log_to_csv_row(log, dataset.name))
     end
   end
   return rows_to_dataframe(rows)

--- a/benchmarking/process_json_to_csv.jl
+++ b/benchmarking/process_json_to_csv.jl
@@ -1,0 +1,171 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Processes a collection of solve results in JSON format into a CSV file.
+#
+# The collection of solve results can correspond to multiple parameter settings.
+# We assume that results for each parameter setting are in a separate directory
+# and are named as *_summary.json, containing serialized SolveLogs.
+# The layout of the results is specified by a JSON file of the following format:
+#
+# {"datasets": [
+#   {"name": "name1", "logs_directory": "path1"},
+#   {"name": "name2", "logs_directory": "path2"}
+#  ] }
+#
+# For example, suppose /tmp/layout.json contains the following content:
+# {"datasets": [
+#   {"name": "pdhg,1e-8", "logs_directory": "/tmp/pdhg_1e-8"},
+#   {"name": "pdhg,1e-4", "logs_directory": "/tmp/pdhg_1e-4"},
+#   {"name": "scs,1e-8", "logs_directory": "/tmp/scs_1e-8"},
+#   {"name": "scs,1e-4", "logs_directory": "/tmp/scs_1e-4"}
+#  ] }
+#
+# Then:
+# $ julia --project=. process_json_to_csv.jl /tmp/layout.json /tmp/dataset.csv
+#
+# will generate a result file in /tmp/dataset.csv containing the summary of each
+# solve in all of four directories, with columns identifying the corresponding
+# configuration.
+
+import CSV
+import DataFrames
+import Glob
+import JSON3
+import StructArrays
+import StructTypes
+
+import FirstOrderLp
+
+const DataFrame = DataFrames.DataFrame
+
+mutable struct CsvRow
+  experiment_name::String
+  instance_name::String
+
+  # These fields correpond to those in ConvergenceInformation.
+  primal_objective::Float64
+  dual_objective::Float64
+  relative_optimality_gap::Float64
+  l2_primal_residual::Float64
+  l_inf_primal_residual::Float64
+  l2_dual_residual::Float64
+  l_inf_dual_residual::Float64
+  relative_l2_primal_residual::Float64
+  relative_l_inf_primal_residual::Float64
+  relative_l2_dual_residual::Float64
+  relative_l_inf_dual_residual::Float64
+  l_inf_primal_variable::Float64
+  l2_primal_variable::Float64
+  l_inf_dual_variable::Float64
+
+  termination_reason::FirstOrderLp.TerminationReason
+  iteration_count::Int32
+  cumulative_kkt_matrix_passes::Float64
+  solve_time_sec::Float64
+end
+
+function CsvRow()
+  return CsvRow(
+    "",  # experiment_name
+    "",  # instance_name
+    NaN,  # primal_objective
+    NaN,  # dual_objective
+    NaN,  # relative_optimality_gap
+    NaN,  # l2_primal_residual
+    NaN,  # l_inf_primal_residual
+    NaN,  # l2_dual_residual
+    NaN,  # l_inf_dual_residual
+    NaN,  # relative_l2_primal_residual
+    NaN,  # relative_l_inf_primal_residual
+    NaN,  # relative_l2_dual_residual
+    NaN,  # relative_l_inf_dual_residual
+    NaN,  # l_inf_primal_variable
+    NaN,  # l2_primal_variable
+    NaN,  # l_inf_dual_variable
+    FirstOrderLp.TERMINATION_REASON_UNSPECIFIED,  # termination_reason
+    0,  # iteration_count
+    NaN,  # cumulative_kkt_matrix_passes
+    NaN,  # solve_time_sec
+  )
+end
+
+function set_matching_fields(to, from)
+  for field_name in intersect(fieldnames(typeof(to)), fieldnames(typeof(from)))
+    setfield!(to, field_name, getfield(from, field_name))
+  end
+end
+
+function solve_log_to_csv_row(
+  log::FirstOrderLp.SolveLog,
+  experiment_name::String,
+)::CsvRow
+  row = CsvRow()
+  set_matching_fields(row, log)
+  row.experiment_name = experiment_name
+  row.cumulative_kkt_matrix_passes =
+    log.solution_stats.cumulative_kkt_matrix_passes
+
+  point_type = log.solution_type
+  # TODO: This doesn't properly handle the case of infeasibility certificates,
+  # whose stats are in log.solution_stats.infeasibility_information.
+  for convergence_information in log.solution_stats.convergence_information
+    if convergence_information.candidate_type == point_type
+      set_matching_fields(row, convergence_information)
+      break
+    end
+  end
+  return row
+end
+
+function rows_to_dataframe(rows::Vector{CsvRow})
+  return DataFrame(; StructArrays.components(StructArrays.StructArray(rows))...)
+end
+
+struct DatasetNameAndLocation
+  name::String
+  logs_directory::String
+end
+
+struct DatasetList
+  datasets::Vector{DatasetNameAndLocation}
+end
+
+StructTypes.StructType(::Type{DatasetNameAndLocation}) = StructTypes.Struct()
+StructTypes.StructType(::Type{DatasetList}) = StructTypes.Struct()
+
+function read_dataset(dataset_list::DatasetList)::DataFrame
+  rows = CsvRow[]
+  for name_and_location in dataset_list.datasets
+    logs_directory = name_and_location.logs_directory
+
+    log_files = Glob.glob("*_summary.json", logs_directory)
+    if length(log_files) == 0
+      error("No *_summary.json files found in $logs_directory.")
+    end
+    for filename in log_files
+      log = JSON3.read(read(filename, String), FirstOrderLp.SolveLog)
+      push!(rows, solve_log_to_csv_row(log, name_and_location.name))
+    end
+  end
+  return rows_to_dataframe(rows)
+end
+
+if length(ARGS) != 2
+  error("Usage: process_json_to_csv.jl dataset_layout_csv output_csv")
+end
+
+dataset_list = JSON3.read(read(ARGS[1], String), DatasetList)
+dataset = read_dataset(dataset_list)
+CSV.write(ARGS[2], dataset)


### PR DESCRIPTION
For processing the results of experiments. The `solve_qp` and `solve_lp_external` scripts generate _summary.json files. This script collects them into a CSV. It allows combining results from multiple directories, where each directory has results corresponding to a different solver configuration.

This isn't fully documented and tested, but I wanted to get feedback on the overall structure first.

TODOs:
- [x] Document in benchmarking/README
- [x] Add CI coverage