### PR TITLE
[workflow] remove tags from push trigger

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ["**"]
   pull_request:
 jobs:
   test:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -2,7 +2,6 @@ name: Format Check
 on:
   push:
     branches: [main]
-    tags: ["**"]
   pull_request:
 jobs:
   test:


### PR DESCRIPTION
The existing actions configuration in CI.yml and format_check.yml trigger:
`
on:
  push:
    branches: [main]
    tags: ["**"]
  pull_request:
`
means that they trigger on any pull request, and on any push EITHER to main, OR any push with a tag. I believe that the intent was any push to main, no matter what tag. This establishes the latter behavior by deleting the tags: entry.

This is an optional suggestion. The only problem with the current setup is potentially triggering CI and format_check more often, in perhaps unexpected situations - I was able to exploit the current setup to test another push that modified CI.yml, by merely adding a tag.