### PR TITLE
[workflow] wrap long lines in CI run steps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, da/workflow]
     tags: ["**"]
   pull_request:
 jobs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,12 +44,6 @@ jobs:
               $GITHUB_WORKSPACE/scripts/solve_qp.jl \
               --instance_path test/trivial_lp_model.mps \
               --method pdhg --output_dir /tmp
-      - name: "solve_qp.jl mirror-prox test"
-        run: |
-          julia --project=$GITHUB_WORKSPACE/scripts \
-              $GITHUB_WORKSPACE/scripts/solve_qp.jl \
-              --instance_path test/trivial_lp_model.mps \
-              --method mirror-prox --output_dir /tmp
       - name: "solve_lp_external.jl test (SCS)"
         run: |
           julia --project=$GITHUB_WORKSPACE/scripts \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main, da/workflow]
+    branches: [main]
     tags: ["**"]
   pull_request:
 jobs:
@@ -44,12 +44,12 @@ jobs:
               $GITHUB_WORKSPACE/scripts/solve_qp.jl \
               --instance_path test/trivial_lp_model.mps \
               --method pdhg --output_dir /tmp
-      - name: "solve_qp.jl mirror_prox test"
+      - name: "solve_qp.jl mirror-prox test"
         run: |
           julia --project=$GITHUB_WORKSPACE/scripts \
               $GITHUB_WORKSPACE/scripts/solve_qp.jl \
               --instance_path test/trivial_lp_model.mps \
-              --method mirror_prox --output_dir /tmp
+              --method mirror-prox --output_dir /tmp
       - name: "solve_lp_external.jl test (SCS)"
         run: |
           julia --project=$GITHUB_WORKSPACE/scripts \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,10 +35,30 @@ jobs:
         with:
           depwarn: error
       - name: "scripts project setup"
-        run: julia --project=$GITHUB_WORKSPACE/scripts -e 'import Pkg; Pkg.instantiate()'
-      - name: "solve_qp.jl test"
-        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_qp.jl --instance_path test/trivial_lp_model.mps --method pdhg --output_dir /tmp
+        run: |
+          julia --project=$GITHUB_WORKSPACE/scripts \
+              -e 'import Pkg; Pkg.instantiate()'
+      - name: "solve_qp.jl pdhg test"
+        run: |
+          julia --project=$GITHUB_WORKSPACE/scripts \
+              $GITHUB_WORKSPACE/scripts/solve_qp.jl \
+              --instance_path test/trivial_lp_model.mps \
+              --method pdhg --output_dir /tmp
+      - name: "solve_qp.jl mirror_prox test"
+        run: |
+          julia --project=$GITHUB_WORKSPACE/scripts \
+              $GITHUB_WORKSPACE/scripts/solve_qp.jl \
+              --instance_path test/trivial_lp_model.mps \
+              --method mirror_prox --output_dir /tmp
       - name: "solve_lp_external.jl test (SCS)"
-        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_lp_external.jl --instance_path test/trivial_lp_model.mps --solver scs-indirect --tolerance 1e-7 --output_dir /tmp
+        run: |
+          julia --project=$GITHUB_WORKSPACE/scripts \
+              $GITHUB_WORKSPACE/scripts/solve_lp_external.jl \
+              --instance_path test/trivial_lp_model.mps \
+              --solver scs-indirect --tolerance 1e-7 --output_dir /tmp
       - name: "solve_lp_external.jl test (HiGHS)"
-        run: julia --project=$GITHUB_WORKSPACE/scripts $GITHUB_WORKSPACE/scripts/solve_lp_external.jl --instance_path test/trivial_lp_model.mps --solver highs-ipm --tolerance 1e-7 --output_dir /tmp
+        run: |
+          julia --project=$GITHUB_WORKSPACE/scripts \
+              $GITHUB_WORKSPACE/scripts/solve_lp_external.jl \
+              --instance_path test/trivial_lp_model.mps \
+              --solver highs-ipm --tolerance 1e-7 --output_dir /tmp

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main, da/workflow]
+    branches: [main]
   pull_request:
 jobs:
   test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, da/workflow]
   pull_request:
 jobs:
   test:


### PR DESCRIPTION
This changes some of the run steps within CI.yml that were becoming quite long to instead use a multi-line format with line continuations.

This will create merge conflicts with [PR#41](https://github.com/google-research/FirstOrderLp.jl/pull/41), so should not be merged until after 41 is resolved and the conflicts resolved, but I'm sending it for review now since it is mostly independent.