### PR TITLE
Rename Malitsky-Pock contraction factor to downscaling factor

### DIFF
--- a/scripts/solve_qp.jl
+++ b/scripts/solve_qp.jl
@@ -429,11 +429,11 @@ function parse_command_line()
     arg_type = Float64
     default = 0.6
 
-    "--malitsky_pock_contraction_factor"
+    "--malitsky_pock_downscaling_factor"
     help =
-      "Malitsky and Pock step size parameter. Contraction factor by " *
-      "which the step size is multiplied for in the inner loop. Corresponds" *
-      "to mu in the paper (https://arxiv.org/pdf/1608.08883.pdf)."
+      "Malitsky and Pock step size parameter. Factor by which the step size " *
+      "is multiplied for in the inner loop. Corresponds to mu in the paper " *
+      "(https://arxiv.org/pdf/1608.08883.pdf)."
     arg_type = Float64
     default = 0.7
 

--- a/src/primal_dual_hybrid_gradient.jl
+++ b/src/primal_dual_hybrid_gradient.jl
@@ -19,10 +19,10 @@ Parameters of the Malitsky and Pock lineseach algorithm
 struct MalitskyPockStepsizeParameters
 
   """
-  Contraction factor by which the step size is multiplied for in the inner
-  loop. Valid values: interval (0, 1). Corresponds to mu in the paper.
+  Factor by which the step size is multiplied for in the inner loop.
+  Valid values: interval (0, 1). Corresponds to mu in the paper.
   """
-  contraction_factor::Float64
+  downscaling_factor::Float64
 
   """
   Breaking factor that defines the stopping criteria of the linesearch.
@@ -609,7 +609,7 @@ function take_step(
       )
       done = true
     end
-    step_size *= step_params.contraction_factor
+    step_size *= step_params.downscaling_factor
   end
   if iter == max_iter && !done
     solver_state.numerical_error = true


### PR DESCRIPTION
Contraction is confusing because the linesearch break criterion could also be seen as contracting the norm of the dual iterates