### PR TITLE
Fixes Issue #55

### DIFF
--- a/src/primal_dual_hybrid_gradient.jl
+++ b/src/primal_dual_hybrid_gradient.jl
@@ -614,8 +614,9 @@ function take_step(
         next_dual_product,
       )
       done = true
+    else
+      step_size *= step_params.downscaling_factor
     end
-    step_size *= step_params.downscaling_factor
   end
   if iter == max_iter && !done
     solver_state.numerical_error = true


### PR DESCRIPTION
Fixes #55 
The code was decreasing the stepsize even when we accepted the step. This was making it going to zero and eventually causing a division by 0.

I ran the example that Miles provided and here is the output:

```
julia --project=scripts scripts/solve_qp.jl --instance_path ~/Downloads/academictimetablesmall.mps.gz \
--method pdhg --output_dir /tmp/first_order_lp_solve --step_size_policy malitsky-pock \
--malitsky_pock_downscaling_factor=0.7 --malitsky_pock_interpolation_coefficient=0.4

Instance: academictimetablesmall
runtime                  | residuals                  |  solution information      | relative residuals      |
#iter   #kkt     seconds | pr norm  du norm   gap     |  pr obj   pr norm  du norm | rel pr  rel du  rel gap |
0       2.5e+00  5.0e-01 | 6.1e+01  0.0e+00   7.0e+00 |  7.0e+00  0.0e+00  0.0e+00 | 3.0e-01 0.0e+00 8.8e-01 |
1280    1.6e+03  3.0e+00 | 4.4e-08  0.0e+00   3.1e-07 | -4.4e-15  1.8e+01  3.4e+02 | 2.2e-10 0.0e+00 3.1e-07 |
Avg solution:
  pr_infeas= 2.68071e-09 pr_obj=-4.440892099e-15 dual_infeas=           0 dual_obj=-3.051967887e-07
  primal norms: L1=    2040.423492, L2=    51.67225148, Linf=    8.192015788
  dual norms:   L1=    6327.256956, L2=    548.3300344, Linf=    166.1532552
Terminated after 1281 iterations: OPTIMAL
Elapsed time: 4.309096687 sec
```