### PR TITLE
Use asymmetric average when using Malitsky & Pock linesearch

### DIFF
--- a/src/mirror_prox.jl
+++ b/src/mirror_prox.jl
@@ -721,7 +721,9 @@ function optimize(
       cumulative_kkt_passes += KKT_PASSES_PER_TERMINATION_EVALUATION
 
       # Compute the average solution since the last restart point.
-      if numerical_error || solution_weighted_avg.sum_solutions_count == 0
+      if numerical_error ||
+         solution_weighted_avg.sum_primal_solutions_count == 0 ||
+         solution_weighted_avg.sum_dual_solutions_count == 0
         avg_primal_solution = primal_part(current_solution)
         avg_dual_solution = dual_part(current_solution)
       else

--- a/src/primal_dual_hybrid_gradient.jl
+++ b/src/primal_dual_hybrid_gradient.jl
@@ -605,8 +605,18 @@ function take_step(
     # sizes cancel out.
     if step_size * norm(delta_dual_product) <=
        step_params.breaking_factor * norm(delta_dual)
-      # TODO: Implement nonsymmetric weighted average (See Theorem 2 of
-      # https://arxiv.org/pdf/1608.08883.pdf)
+      # Malitsky and Pock guarantee uses a nonsymmetric weighted average, the
+      # primal variable average involves the initial point, while the dual
+      # doesn't. See Theorem 2 in https://arxiv.org/pdf/1608.08883.pdf for
+      # details.
+      if solver_state.solution_weighted_avg.sum_primal_solutions_count == 0
+        add_to_primal_solution_weighted_average(
+          solver_state.solution_weighted_avg,
+          solver_state.current_primal_solution,
+          step_size * ratio_step_sizes,
+        )
+      end
+
       update_solution_in_solver_state(
         solver_state,
         next_primal,
@@ -876,7 +886,8 @@ function optimize(
         KKT_PASSES_PER_TERMINATION_EVALUATION
       # Compute the average solution since the last restart point.
       if solver_state.numerical_error ||
-         solver_state.solution_weighted_avg.sum_solutions_count == 0
+         solver_state.solution_weighted_avg.sum_primal_solutions_count == 0 ||
+         solver_state.solution_weighted_avg.sum_dual_solutions_count == 0
         avg_primal_solution = solver_state.current_primal_solution
         avg_dual_solution = solver_state.current_dual_solution
       else

--- a/src/saddle_point.jl
+++ b/src/saddle_point.jl
@@ -391,11 +391,6 @@ mutable struct RestartParameters
   """
   primal_weight_update_smoothing::Float64
 
-  """
-  Use an approximate localized duality gap for restart computations. The
-  approximate gap only enforces bounds on variables that are active at the
-  center point and objective.
-  """
   use_approximate_localized_duality_gap::Bool
 end
 

--- a/src/saddle_point.jl
+++ b/src/saddle_point.jl
@@ -215,15 +215,24 @@ end
 mutable struct SolutionWeightedAverage
   sum_primal_solutions::Vector{Float64}
   sum_dual_solutions::Vector{Float64}
-  sum_solutions_count::Int64
-  sum_solution_weights::Float64
+  sum_primal_solutions_count::Int64
+  sum_dual_solutions_count::Int64
+  sum_primal_solution_weights::Float64
+  sum_dual_solution_weights::Float64
 end
 
 function initialize_solution_weighted_average(
   primal_size::Int64,
   dual_size::Int64,
 )
-  return SolutionWeightedAverage(zeros(primal_size), zeros(dual_size), 0, 0.0)
+  return SolutionWeightedAverage(
+    zeros(primal_size),
+    zeros(dual_size),
+    0,
+    0,
+    0.0,
+    0.0,
+  )
 end
 
 function reset_solution_weighted_average(
@@ -233,8 +242,35 @@ function reset_solution_weighted_average(
     zeros(length(solution_weighted_avg.sum_primal_solutions))
   solution_weighted_avg.sum_dual_solutions =
     zeros(length(solution_weighted_avg.sum_dual_solutions))
-  solution_weighted_avg.sum_solutions_count = 0
-  solution_weighted_avg.sum_solution_weights = 0.0
+  solution_weighted_avg.sum_primal_solutions_count = 0
+  solution_weighted_avg.sum_dual_solutions_count = 0
+  solution_weighted_avg.sum_primal_solution_weights = 0.0
+  solution_weighted_avg.sum_dual_solution_weights = 0.0
+  return
+end
+
+function add_to_primal_solution_weighted_average(
+  solution_weighted_avg::SolutionWeightedAverage,
+  current_primal_solution::AbstractVector{Float64},
+  weight::Float64,
+)
+  @assert solution_weighted_avg.sum_primal_solutions_count >= 0
+  solution_weighted_avg.sum_primal_solutions .+=
+    current_primal_solution * weight
+  solution_weighted_avg.sum_primal_solutions_count += 1
+  solution_weighted_avg.sum_primal_solution_weights += weight
+  return
+end
+
+function add_to_dual_solution_weighted_average(
+  solution_weighted_avg::SolutionWeightedAverage,
+  current_dual_solution::AbstractVector{Float64},
+  weight::Float64,
+)
+  @assert solution_weighted_avg.sum_dual_solutions_count >= 0
+  solution_weighted_avg.sum_dual_solutions .+= current_dual_solution * weight
+  solution_weighted_avg.sum_dual_solutions_count += 1
+  solution_weighted_avg.sum_dual_solution_weights += weight
   return
 end
 
@@ -244,20 +280,24 @@ function add_to_solution_weighted_average(
   current_dual_solution::AbstractVector{Float64},
   weight::Float64,
 )
-  @assert solution_weighted_avg.sum_solutions_count >= 0
-  solution_weighted_avg.sum_primal_solutions .+=
-    current_primal_solution * weight
-  solution_weighted_avg.sum_dual_solutions .+= current_dual_solution * weight
-  solution_weighted_avg.sum_solutions_count += 1
-  solution_weighted_avg.sum_solution_weights += weight
+  add_to_primal_solution_weighted_average(
+    solution_weighted_avg,
+    current_primal_solution,
+    weight,
+  )
+  add_to_dual_solution_weighted_average(
+    solution_weighted_avg,
+    current_dual_solution,
+    weight,
+  )
   return
 end
 
 function compute_average(solution_weighted_avg::SolutionWeightedAverage)
   return solution_weighted_avg.sum_primal_solutions /
-         solution_weighted_avg.sum_solution_weights,
+         solution_weighted_avg.sum_primal_solution_weights,
   solution_weighted_avg.sum_dual_solutions /
-  solution_weighted_avg.sum_solution_weights
+  solution_weighted_avg.sum_dual_solution_weights
 end
 
 """
@@ -351,6 +391,11 @@ mutable struct RestartParameters
   """
   primal_weight_update_smoothing::Float64
 
+  """
+  Use an approximate localized duality gap for restart computations. The
+  approximate gap only enforces bounds on variables that are active at the
+  center point and objective.
+  """
   use_approximate_localized_duality_gap::Bool
 end
 
@@ -618,12 +663,12 @@ accordingly.
    this struct will be reset to the restart point.
 - `current_primal_solution::AbstractVector`: If there is a restart then this
    vector might be set to the avg_primal_solution. However, it could remain
-   unchanged, if the algorithm thinks the averaged iterate is better than the
-   current iterate.
+   unchanged, if the algorithm thinks the current iterate is better than the
+   averaged iterate.
 - `current_dual_solution::AbstractVector`: If there is a restart then this
    vector might be set to the avg_dual_solution. However, it could remain
-   unchanged, if the algorithm thinks the averaged iterate is better than the
-   current iterate.
+   unchanged, if the algorithm thinks the current iterate is better than the
+   averaged iterate.
 - `last_restart_info::RestartInfo`: Information stored about the last
    restart point.
 - `iterations_completed::Int64`: The number of successful iterations completed
@@ -655,14 +700,15 @@ function run_restart_scheme(
 )
   # TODO: Add options for the purposes of benchmarking, e.g., use the
   # last iterate instead of the average, or average across all iterates.
-  if solution_weighted_avg.sum_solutions_count > 0
+  if solution_weighted_avg.sum_primal_solutions_count > 0 &&
+     solution_weighted_avg.sum_dual_solutions_count > 0
     avg_primal_solution, avg_dual_solution =
       compute_average(solution_weighted_avg)
   else
     return RESTART_CHOICE_NO_RESTART
   end
 
-  restart_length = solution_weighted_avg.sum_solutions_count
+  restart_length = solution_weighted_avg.sum_primal_solutions_count
   artificial_restart = false
   do_restart = false
   # If we have not restarted for a very long time (as a fraction of the

--- a/src/saddle_point.jl
+++ b/src/saddle_point.jl
@@ -663,12 +663,12 @@ accordingly.
    this struct will be reset to the restart point.
 - `current_primal_solution::AbstractVector`: If there is a restart then this
    vector might be set to the avg_primal_solution. However, it could remain
-   unchanged, if the algorithm thinks the current iterate is better than the
-   averaged iterate.
+   unchanged, if the algorithm thinks the averaged iterate is better than the
+   current iterate.
 - `current_dual_solution::AbstractVector`: If there is a restart then this
    vector might be set to the avg_dual_solution. However, it could remain
-   unchanged, if the algorithm thinks the current iterate is better than the
-   averaged iterate.
+   unchanged, if the algorithm thinks the averaged iterate is better than the
+   current iterate.
 - `last_restart_info::RestartInfo`: Information stored about the last
    restart point.
 - `iterations_completed::Int64`: The number of successful iterations completed


### PR DESCRIPTION
Addresses a TODO in the Malitsky & Pock linesearch code.  The theory requires using an asymmetric average - including the primal starting point in the average (with a somewhat unusual weight), but not the dual starting point.  This changes the code to match the theory.

However, one caveat: on the one test instance I've run, academictimetablesmall with defaults except --method pdhg --step_size_policy=malitsky-pock, this change increases the number of iterations to solve from 1241 to 2041 (and kkt passes from 1.9e3 to 3.2e3).  I haven't run a larger benchmark.  I'm not sure this matters, but I found it interesting.

Note that supporting this required splitting the denominator in the average structure into primal and dual portions.  There were several places that tested whether the denominator was nonzero (before computing an average) - this changes them to require both denominators to be nonzero.  For the current code, this change is a no-op - they will be non-zero together, but it makes it clearer at the call site what's going on, rather than just testing one or the other.