### PR TITLE
Add field comment for use_approximate_localized_duality_gap

### DIFF
--- a/src/saddle_point.jl
+++ b/src/saddle_point.jl
@@ -351,6 +351,11 @@ mutable struct RestartParameters
   """
   primal_weight_update_smoothing::Float64
 
+  """
+  Use an approximate localized duality gap for restart computations. The
+  approximate gap only enforces bounds on variables that are active at the
+  center point and objective.
+  """
   use_approximate_localized_duality_gap::Bool
 end
 


### PR DESCRIPTION
I noticed that RestartParameters::use_approximate_localized_duality_gap didn't have a field comment (while all other RestartParameters do).  This change adds a descriptive comment.