### PR TITLE
Swap current/averaged in current_{primal,dual}_solution comments

### DIFF
--- a/src/saddle_point.jl
+++ b/src/saddle_point.jl
@@ -618,12 +618,12 @@ accordingly.
    this struct will be reset to the restart point.
 - `current_primal_solution::AbstractVector`: If there is a restart then this
    vector might be set to the avg_primal_solution. However, it could remain
-   unchanged, if the algorithm thinks the averaged iterate is better than the
-   current iterate.
+   unchanged, if the algorithm thinks the current iterate is better than the
+   averaged iterate.
 - `current_dual_solution::AbstractVector`: If there is a restart then this
    vector might be set to the avg_dual_solution. However, it could remain
-   unchanged, if the algorithm thinks the averaged iterate is better than the
-   current iterate.
+   unchanged, if the algorithm thinks the current iterate is better than the
+   averaged iterate.
 - `last_restart_info::RestartInfo`: Information stored about the last
    restart point.
 - `iterations_completed::Int64`: The number of successful iterations completed


### PR DESCRIPTION
The argument descriptions for the current_primal_solution and current_dual_solution inputs to run_restart_scheme swapped "current" and "averaged" in their specification of when the current_primal_solution would/wouldn't be changed.  This corrects them.