### PR TITLE
Simplify collect_LIBSVM.sh

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -66,9 +66,10 @@ https://papers.nips.cc/paper/2003/file/49d4b2faeb4b7b9e745775793141e2b2-Paper.pd
 For example,
 
 ```sh
-$ ./collect_LIBSVM.sh $HOME/LIBSVM
-$ julia --project=. generate_l1_svm_lp.jl --input_filename=$HOME/LIBSVM/duke \
-	  --output_filename=$HOME/LIBSVM/duke.mps.gz --regularizer_weight=1.0
+$ ./collect_LIBSVM.sh ${HOME}/LIBSVM
+$ julia --project=. generate_l1_svm_lp.jl \
+--input_filename=${HOME}/LIBSVM/duke \
+	  --output_filename=${HOME}/LIBSVM/duke.mps.gz --regularizer_weight=1.0
 ```
 
 ## Pagerank instances

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -66,9 +66,9 @@ https://papers.nips.cc/paper/2003/file/49d4b2faeb4b7b9e745775793141e2b2-Paper.pd
 For example,
 
 ```sh
-$ ./collect_LIBSVM.sh /tmp ~/LIBSVM
-$ julia --project=. generate_l1_svm_lp.jl --input_filename=~/LIBSVM/duke \
-	  --output_filename=~/LIBSVM/duke.mps.gz --regularizer_weight=1.0
+$ ./collect_LIBSVM.sh $HOME/LIBSVM
+$ julia --project=. generate_l1_svm_lp.jl --input_filename=$HOME/LIBSVM/duke \
+	  --output_filename=$HOME/LIBSVM/duke.mps.gz --regularizer_weight=1.0
 ```
 
 ## Pagerank instances

--- a/benchmarking/collect_LIBSVM.sh
+++ b/benchmarking/collect_LIBSVM.sh
@@ -18,21 +18,18 @@
 # and working.
 
 
-if [[ "$#" != 2 ]]; then
-    echo "Usage: collect_LIBSVM.sh temporary_dir output_dir" 1>&2
+if [[ "$#" != 1 ]]; then
+    echo "Usage: collect_LIBSVM.sh output_dir" 1>&2
     exit 1
 fi
 
-TEMP_DIR="$1"
-DEST_DIR="$2"
+DEST_DIR="$1"
 
-mkdir -p "${TEMP_DIR}" || exit 1
 mkdir -p "${DEST_DIR}" || exit 1
 
 # To download the binary problems:
 data_source="https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary"
 for filename in kdda.t real-sim avazu-app.val; do
-    curl "${data_source}/${filename}.bz2" --output "${TEMP_DIR}/${filename}.bz2" || exit 1
-    bunzip2 -d "${TEMP_DIR}/${filename}.bz2"
-    mv "${TEMP_DIR}/${filename}" "${DEST_DIR}/${filename}"
+    curl "${data_source}/${filename}.bz2" --output "${DEST_DIR}/${filename}.bz2" || exit 1
+    bunzip2 "${DEST_DIR}/${filename}.bz2"
 done


### PR DESCRIPTION
The temporary directory isn't necessary, and `bunzip2` is already equivalent to `bzip2 -d`.