### PR TITLE
Add a lower bound on the l1 auxiliary variables

### DIFF
--- a/benchmarking/generate_l1_svm_lp.jl
+++ b/benchmarking/generate_l1_svm_lp.jl
@@ -60,7 +60,7 @@ function populate_libsvm_model(
   println("Generating a model with $n datapoints and $(d - 1) features.")
   JuMP.@variable(model, beta[i = 1:d])
   JuMP.@variable(model, w[i = 1:n], lower_bound = 0.0)
-  JuMP.@variable(model, z[i = 1:d])
+  JuMP.@variable(model, z[i = 1:d], lower_bound = 0.0)
   JuMP.@objective(model, Min, sum(w) + regularizer_weight * sum(z))
   JuMP.@constraint(model, z .>= beta)
   JuMP.@constraint(model, z .>= -beta)


### PR DESCRIPTION
In a small test, this results in a slight performance boost for PDHG.