### PR TITLE
Cleanup benchmarking

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -43,13 +43,19 @@ linear programming benchmark sites
 3. Download and build PaPILO from https://github.com/lgottwald/PaPILO.
 4. From the local directory, run `./preprocess.sh`.
 
+`collect_lp_benchmark.sh` has the following argument structure:
+
+```sh
+$ ./collect_lp_benchmark.sh temporary_directory output_directory
+```
+
 For example, assuming you have already instantiated the packages and built
 PaPILO,
 
 ```sh
-$ ./collect_lp_benchmark.sh /tmp ~/lp_benchmark
-$ ./preprocess.sh ~/lp_benchmark ./lp_benchmark_instance_list \
-    ~/lp_benchmark_preprocessed ~/PaPILO/build/bin/papilo
+$ ./collect_lp_benchmark.sh /tmp "${HOME}/lp_benchmark"
+$ ./preprocess.sh "${HOME}/lp_benchmark" ./lp_benchmark_instance_list \
+    "${HOME}/lp_benchmark_preprocessed" "${HOME}/PaPILO/build/bin/papilo"
 ```
 
 ## L1 SVM
@@ -67,10 +73,10 @@ https://papers.nips.cc/paper/2003/file/49d4b2faeb4b7b9e745775793141e2b2-Paper.pd
 For example,
 
 ```sh
-$ ./collect_LIBSVM.sh ${HOME}/LIBSVM
+$ ./collect_LIBSVM.sh "${HOME}/LIBSVM"
 $ julia --project=. generate_l1_svm_lp.jl \
---input_filename=${HOME}/LIBSVM/duke \
-	  --output_filename=${HOME}/LIBSVM/duke.mps.gz --regularizer_weight=1.0
+    --input_filename="${HOME}/LIBSVM/duke" \
+    --output_filename="${HOME}/LIBSVM/duke.mps.gz" --regularizer_weight=1.0
 ```
 
 ## Pagerank instances
@@ -90,7 +96,7 @@ For example,
 ```sh
 $ julia --project=. generate_pagerank_lp.jl --num_nodes 10000 \
     --approx_num_edges 30000 --random_seed 1 \
-    --output_filename ~/pagerank.10k.mps.gz
+    --output_filename "${HOME}/pagerank.10k.mps.gz"
 ```
 ## Procesing JSON results
 

--- a/benchmarking/collect_LIBSVM.sh
+++ b/benchmarking/collect_LIBSVM.sh
@@ -19,7 +19,7 @@
 
 
 if [[ "$#" != 1 ]]; then
-    echo "Usage: collect_LIBSVM.sh output_dir" 1>&2
+    echo "Usage: collect_LIBSVM.sh output_directory" 1>&2
     exit 1
 fi
 

--- a/benchmarking/collect_lp_benchmark.sh
+++ b/benchmarking/collect_lp_benchmark.sh
@@ -26,7 +26,8 @@
 #     http://plato.asu.edu/ftp/network.html
 
 if [[ "$#" != 2 ]]; then
-  echo "Usage: collect_lp_benchmark.sh temporary_dir output_dir" 1>&2
+  echo "Usage: collect_lp_benchmark.sh temporary_directory" \
+    "output_directory" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
This makes several cleanups to the benchmarking scripts and README.md:

1. Be more consistent about using $HOME/ instead ~/
2. Be more consistent about quoting
3. Use "directory" instead of "dir", both in README.md descriptions and in usage strings
4. Include a description of script argument for each script mentioned in README.md
5. Be a bit more consistent about indentation