### PR TITLE
Record iteration stats if we are terminating

### DIFF
--- a/scripts/solve_qp.jl
+++ b/scripts/solve_qp.jl
@@ -351,7 +351,9 @@ function parse_command_line()
     help =
       "Whether we record iterations stats. If true then record an " *
       "IterationStats object with frequency (in iterations) " *
-      "equal to termination_evaluation_frequency."
+      "equal to termination_evaluation_frequency. If false then " *
+      "only record the iteration stats for the final (terminating) " *
+      "iteration."
     arg_type = Bool
     default = true
 

--- a/src/mirror_prox.jl
+++ b/src/mirror_prox.jl
@@ -103,7 +103,8 @@ struct MirrorProxParameters
   verbosity::Int64
 
   """
-  Whether to record an IterationStats object.
+  Whether to record an IterationStats object. If false, only iteration stats
+  for the final (terminating) iteration are recorded.
   """
   record_iteration_stats::Bool
 

--- a/src/mirror_prox.jl
+++ b/src/mirror_prox.jl
@@ -772,9 +772,6 @@ function optimize(
         primal_part(p.mirror_map_scaling),
         dual_part(p.mirror_map_scaling),
       )
-      if params.record_iteration_stats
-        push!(iteration_stats, current_iteration_stats)
-      end
 
       # Check the termination criteria.
       termination_reason = check_termination_criteria(
@@ -784,6 +781,12 @@ function optimize(
       )
       if numerical_error && termination_reason == false
         termination_reason = TERMINATION_REASON_NUMERICAL_ERROR
+      end
+
+      # If we're terminating, record the iteration stats to provide final
+      # solution stats.
+      if params.record_iteration_stats || termination_reason != false
+        push!(iteration_stats, current_iteration_stats)
       end
 
       mirror_prox_display(

--- a/src/primal_dual_hybrid_gradient.jl
+++ b/src/primal_dual_hybrid_gradient.jl
@@ -942,10 +942,6 @@ function optimize(
         primal_norm_params,
         dual_norm_params,
       )
-      if params.record_iteration_stats
-        push!(iteration_stats, current_iteration_stats)
-      end
-
       # Check the termination criteria.
       termination_reason = check_termination_criteria(
         termination_criteria,
@@ -954,6 +950,12 @@ function optimize(
       )
       if solver_state.numerical_error && termination_reason == false
         termination_reason = TERMINATION_REASON_NUMERICAL_ERROR
+      end
+
+      # If we're terminating, record the iteration stats to provide final
+      # solution stats.
+      if params.record_iteration_stats || termination_reason != false
+        push!(iteration_stats, current_iteration_stats)
       end
 
       # Print table.

--- a/src/primal_dual_hybrid_gradient.jl
+++ b/src/primal_dual_hybrid_gradient.jl
@@ -165,7 +165,8 @@ struct PdhgParameters
   verbosity::Int64
 
   """
-  Whether to record an IterationStats object.
+  Whether to record an IterationStats object. If false, only iteration stats
+  for the final (terminating) iteration are recorded.
   """
   record_iteration_stats::Bool
 


### PR DESCRIPTION
Record iteration stats if we are terminating, even if record_iteration_stats == false.

This is necessary for solve_qp.jl to report solution stats, since it uses the last entry in iteration_stats as solution_stats.
