### PR TITLE
Add pyproject.toml to configure black line-length

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 80


### PR DESCRIPTION
This means that `black analyze_csv_data.py` will use the correct line length, instead of requiring `black --line-length=80 analyze_csv_data.py`