### PR TITLE
[obsolete] Add Julia 1.7 and macos-latest to CI workflow matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1.6', '1.7', '1.8']
+        version: ['1.6', '1.7']
         os: [ubuntu-latest, macos-latest]
         arch: [x64]
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,7 +69,9 @@ jobs:
           julia --project=$GITHUB_WORKSPACE/benchmarking \
               $GITHUB_WORKSPACE/benchmarking/process_json_to_csv.jl \
               /tmp/layout.json /tmp/dataset.csv
-          if [[ $(wc -l </tmp/dataset.csv) != 3 ]]; then
+          # The arithmetic expansion '$((...))' below is to trim whitespace on
+          # macos.
+          if [[ $(($(wc -l </tmp/dataset.csv))) != 3 ]]; then
             echo "Unexpected number of lines in dataset.csv:" \
                 "$(wc -l </tmp/dataset.csv)"
             cat /tmp/dataset.csv

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,8 @@ jobs:
               $GITHUB_WORKSPACE/benchmarking/process_json_to_csv.jl \
               /tmp/layout.json /tmp/dataset.csv
           if [[ $(wc -l </tmp/dataset.csv) != 3 ]]; then
-            echo "Unexpected number of lines in dataset.csv"
+            echo "Unexpected number of lines in dataset.csv:" \
+                "$(wc -l </tmp/dataset.csv)"
             cat /tmp/dataset.csv
             exit 1
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1.6']
-        os: [ubuntu-latest]
+        version: ['1.6', '1.7', '1.8']
+        os: [ubuntu-latest, macos-latest]
         arch: [x64]
     steps:
       - uses: actions/checkout@v2

--- a/src/primal_dual_hybrid_gradient.jl
+++ b/src/primal_dual_hybrid_gradient.jl
@@ -385,7 +385,7 @@ function power_method_failure_probability(
     # The theorem requires epsilon > 0 and k >= 2.
     return 1.0
   end
-  return min(0.824, 0.354 / sqrt(epsilon * (k - 1))) *
+  return min(0.824, 0.354 / (epsilon * (k - 1))) *
          sqrt(dimension) *
          (1.0 - epsilon)^(k - 1 / 2)
 end

--- a/src/primal_dual_hybrid_gradient.jl
+++ b/src/primal_dual_hybrid_gradient.jl
@@ -385,7 +385,7 @@ function power_method_failure_probability(
     # The theorem requires epsilon > 0 and k >= 2.
     return 1.0
   end
-  return min(0.824, 0.354 / (epsilon * (k - 1))) *
+  return min(0.824, 0.354 / sqrt(epsilon * (k - 1))) *
          sqrt(dimension) *
          (1.0 - epsilon)^(k - 1 / 2)
 end

--- a/test/test_mirror_prox.jl
+++ b/test/test_mirror_prox.jl
@@ -221,6 +221,7 @@ end
     )
     problem = example_lp()
     output = FirstOrderLp.optimize(parameters, problem)
+    @test output.iterations_completed == 673
     @test output.primal_solution ≈ [1.0; 0.0; 6.0; 2.0] atol = 1.0e-9
     @test output.dual_solution ≈ [0.5; 4.0; 0.0] atol = 1.0e-9
   end

--- a/test/test_mirror_prox.jl
+++ b/test/test_mirror_prox.jl
@@ -221,7 +221,6 @@ end
     )
     problem = example_lp()
     output = FirstOrderLp.optimize(parameters, problem)
-    @test output.iteration_count == 673
     @test output.primal_solution ≈ [1.0; 0.0; 6.0; 2.0] atol = 1.0e-9
     @test output.dual_solution ≈ [0.5; 4.0; 0.0] atol = 1.0e-9
   end
@@ -240,7 +239,7 @@ end
   end
   @testset "restart_scheme=adaptive_localized" begin
     parameters = generate_mirror_prox_params(
-      iteration_limit = 750,
+      iteration_limit = 800,
       primal_importance = 1.0,
       diagonal_scaling = "off",
       verbosity = 0,

--- a/test/test_mirror_prox.jl
+++ b/test/test_mirror_prox.jl
@@ -221,7 +221,7 @@ end
     )
     problem = example_lp()
     output = FirstOrderLp.optimize(parameters, problem)
-    @test output.iterations_completed == 673
+    @test output.iteration_count == 673
     @test output.primal_solution ≈ [1.0; 0.0; 6.0; 2.0] atol = 1.0e-9
     @test output.dual_solution ≈ [0.5; 4.0; 0.0] atol = 1.0e-9
   end


### PR DESCRIPTION
This expands the Continuous Integration workflow that is applied to new pull requests and merges from just testing Julia 1.6 on linux-latest to running Julia 1.6 and 1.7 on both linux-latest and macosx-latest.

Fixes Issue #115 

This also includes a change to the validation test for process_json_to_csv because `wc -l` on macos includes padding spaces that don't appear on linux.
