### PR TITLE
Add Julia 1.7 and macos-latest to CI workflow matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1.6', '1.7', '1.8']
+        version: ['1.6', '1.7']
         os: [ubuntu-latest, macos-latest]
         arch: [x64]
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,7 +69,9 @@ jobs:
           julia --project=$GITHUB_WORKSPACE/benchmarking \
               $GITHUB_WORKSPACE/benchmarking/process_json_to_csv.jl \
               /tmp/layout.json /tmp/dataset.csv
-          if [[ $(wc -l </tmp/dataset.csv) != 3 ]]; then
+          # The arithmetic expansion '$((...))' below is to trim whitespace on
+          # macos.
+          if [[ $(($(wc -l </tmp/dataset.csv))) != 3 ]]; then
             echo "Unexpected number of lines in dataset.csv"
             cat /tmp/dataset.csv
             exit 1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1.6']
-        os: [ubuntu-latest]
+        version: ['1.6', '1.7', '1.8']
+        os: [ubuntu-latest, macos-latest]
         arch: [x64]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This expands the Continuous Integration workflow that is applied to new pull requests and merges from just testing Julia 1.6 on linux-latest to running Julia 1.6 and 1.7 on both linux-latest and macosx-latest.

This also includes a change to the validation test for process_json_to_csv because `wc -l` on macos includes padding spaces that don't appear on linux.

Fixes #115

- [x ] Tests pass
- [x ] Appropriate changes to README are included in PR (no README changes needed)
